### PR TITLE
force building of docker images from git

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ awx_repo_dir: "~/awx"
 awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
+awx_build_images_from_git: yes

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,9 +1,19 @@
 ---
+- name: Flip a flag to force docker images to be built locally
+  lineinfile:
+    path: "{{ awx_repo_dir }}/installer/inventory"
+    regexp: '^dockerhub_base=ansible'
+    line: '#dockerhub_base=ansible'
+  when: awx_build_images_from_git 
+
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml"
+  command: "ansible-playbook  -i inventory install.yml "
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete
+  register: aws_local_run
+
+- debug: msg="{{ aws_local_run }}"
 
 - name: Create a file to mark whether this playbook has completed.
   file:


### PR DESCRIPTION
The install script will pull images from docker hub by default,
which is much faster, however not what I think this role
sets out to do

i've created a flag: "awx_build_images_from_git" which when set will remove a line from the shipped inventory in the install
directory to force the installer to build the docker images