### PR TITLE
Add host_port to execution of installer playbook on awx 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Available variables are listed below, along with default values (see `defaults/m
     awx_repo_dir: "~/awx"
     awx_version: devel
     awx_keep_updated: yes
+    awx_host_port: 3001
 
 Variables to control what version of AWX is checked out and installed.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ awx_repo_dir: "~/awx"
 awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
+awx_host_port: 3001

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml"
+  command: "ansible-playbook -i inventory install.yml -e host_port={{ awx_host_port }}"
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete


### PR DESCRIPTION
Define a awx_host_port variable to assign different port of 80 (default) on build and start container.