### PR TITLE
Add optional tasks for monolithic install #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,6 @@
 
 Installs and configures [AWX](https://github.com/ansible/awx), the open source version of [Ansible Tower](https://www.ansible.com/tower).
 
-## Requirements
-
-Before this role runs, assuming you want the role to completely set up AWX using it's included installer, you need to make sure the following AWX dependencies are installed:
-
-| Dependency                    | Suggested Role           |
-| ----------------------------- | ------------------------ |
-| EPEL repo (RedHat OSes only)  | `geerlingguy.repo-epel`  |
-| Git                           | `geerlingguy.git`        |
-| Ansible                       | `geerlingguy.ansible`    |
-| Docker                        | `geerlingguy.docker`     |
-| Python Pip                    | `geerlingguy.pip`        |
-| Node.js (6.x)                 | `geerlingguy.nodejs`     |
-
-See this role's `tests/test.yml` playbook for an example that works across many different OSes.
-
 ## Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
@@ -32,30 +17,43 @@ Variables to control what version of AWX is checked out and installed.
 
     awx_run_install_playbook: yes
 
+Variables defined by this role for the dependencies:
+    
+ - geerlingguy.pip:
+
+        pip_install_packages:
+            - name: docker-py
+
+- geerlingguy.nodejs:
+    
+        nodejs_version: "6.x"
+
 By default, this role will run the installation playbook included with AWX (which builds a set of containers and runs them). You can disable the playbook run by setting this variable to `no`.
 
 ## Dependencies
 
-None.
+When you install this role using Galaxy the following AWX dependencies are also installed (automatically):
+
+| Dependency                    | Suggested Role           |
+| ----------------------------- | ------------------------ |
+| EPEL repo (RedHat OSes only)  | `geerlingguy.repo-epel`  |
+| Git                           | `geerlingguy.git`        |
+| Ansible                       | `geerlingguy.ansible`    |
+| Docker                        | `geerlingguy.docker`     |
+| Python Pip                    | `geerlingguy.pip`        |
+| Node.js (6.x)                 | `geerlingguy.nodejs`     |
+
+See this role's `tests/test.yml` playbook for an example that works across many different OSes.
 
 ## Example Playbook
 
-    - hosts: awx-centos
+```YAML
+    - hosts: awx-centos
       become: yes
-    
-      vars:
-        nodejs_version: "6.x"
-        pip_install_packages:
-          - name: docker-py
-    
+        
       roles:
-        - geerlingguy.repo-epel
-        - geerlingguy.git
-        - geerlingguy.ansible
-        - geerlingguy.docker
-        - geerlingguy.pip
-        - geerlingguy.nodejs
-        - geerlingguy.awx
+        - geerlingguy.awx
+```
 
 After AWX is installed, you can log in with the default username `admin` and password `password`.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Variables to control what version of AWX is checked out and installed.
 
     awx_run_install_playbook: yes
 
-Variables defined by this role for the dependencies:
+Variables defined by this role for the dependencies
     
  - geerlingguy.pip:
 
@@ -32,7 +32,7 @@ By default, this role will run the installation playbook included with AWX (whic
 
 ## Dependencies
 
-When you install this role using Galaxy the following AWX dependencies are also installed (automatically):
+When you install this role using Galaxy the following AWX dependencies are also installed automatically (see : `meta/main.yml`)
 
 | Dependency                    | Suggested Role           |
 | ----------------------------- | ------------------------ |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,9 +7,9 @@ awx_run_install_playbook: yes
 postgres_data_dir: /var/lib/pgdocker
 
 #### Dependencies
-## pip
+## geerlingguy.pip
 pip_install_packages:
   - name: docker-py
 
-## nodejs
+## geerlingguy.nodejs
 nodejs_version: "6.x"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,11 @@ awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
 postgres_data_dir: /var/lib/pgdocker
+
+#### Dependencies
+## pip
+pip_install_packages:
+  - name: docker-py
+
+## nodejs
+nodejs_version: "6.x"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,15 @@
 ---
-dependencies: []
+dependencies:
+  - role: geerlingguy.repo-epel
+  - role: geerlingguy.git
+  - role: geerlingguy.ansible
+  - role: geerlingguy.docker
+  - role: geerlingguy.pip
+    pip_install_packages:
+      - name: docker-py
+  - role: geerlingguy.nodejs
+    nodejs_version: "6.x"
+  - role: geerlingguy.awx
 
 galaxy_info:
   author: geerlingguy

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   - role: geerlingguy.repo-epel
+    when: ansible_os_version == 'RedHat'
   - role: geerlingguy.git
   - role: geerlingguy.ansible
   - role: geerlingguy.docker

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,10 +5,7 @@ dependencies:
   - role: geerlingguy.ansible
   - role: geerlingguy.docker
   - role: geerlingguy.pip
-    pip_install_packages:
-      - name: docker-py
   - role: geerlingguy.nodejs
-    nodejs_version: "6.x"
   - role: geerlingguy.awx
 
 galaxy_info:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 dependencies:
   - role: geerlingguy.repo-epel
-    when: ansible_os_version == 'RedHat'
+    when: ansible_os_family == 'RedHat'
   - role: geerlingguy.git
   - role: geerlingguy.ansible
   - role: geerlingguy.docker

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,6 @@ dependencies:
   - role: geerlingguy.docker
   - role: geerlingguy.pip
   - role: geerlingguy.nodejs
-  - role: geerlingguy.awx
 
 galaxy_info:
   author: geerlingguy

--- a/tests/test-no-playbook.yml
+++ b/tests/test-no-playbook.yml
@@ -11,5 +11,4 @@
       changed_when: false
 
   roles:
-    - geerlingguy.git
     - role_under_test

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,11 +1,6 @@
 ---
 - hosts: all
 
-  vars:
-    nodejs_version: "6.x"
-    pip_install_packages:
-      - name: docker-py
-
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
@@ -13,11 +8,4 @@
       changed_when: false
 
   roles:
-    - name: geerlingguy.repo-epel
-      when: ansible_os_family == "RedHat"
-    - geerlingguy.git
-    - geerlingguy.ansible
-    - geerlingguy.docker
-    - geerlingguy.pip
-    - geerlingguy.nodejs
     - role_under_test


### PR DESCRIPTION
Rely on Galaxy to manage dependencies.