### PR TITLE
Use command line options or inventory file when running the installer

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,13 @@ awx_repo_dir: "~/awx"
 awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
-postgres_data_dir: /var/lib/pgdocker
+modify_awx_inventory: true
+inventory:
+    dockerhub_base:
+        value: ansible
+        disabled: false
+    dockerhub_version: 
+        value: latest
+        disabled: false
+    postgres_data_dir: 
+        value: /var/lib/pgdocker

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,10 +1,47 @@
 ---
-- name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }}"
-  args:
-    chdir: "{{ awx_repo_dir }}/installer"
-    creates: /etc/awx_playbook_complete
+- name: Run the installer with command line options
+  block:
+    - name: create command line options when not using the inventory.
+      set_fact: 
+        installer_args: |
+            {% for k,v in inventory.iteritems() -%}
+            -e {{ k }}={{ v }}{{ '' if loop.last else ' ' }}
+            {%- endfor -%}
 
+    - name: Run the AWX installation playbook with command line args.
+      command: "ansible-playbook -i inventory install.yml {{ installer_args }}"
+      args:
+        chdir: "{{ awx_repo_dir }}/installer"
+        creates: /etc/awx_playbook_complete
+  when: not modify_awx_inventory
+
+- name: Run the installer with the inventory file
+  block:
+    - name: Enable/Change settings in the awx inventory file from upstream
+      lineinfile:
+        destfile: "{{ awx_repo_dir }}/installer/inventory"
+        regexp: '^\s*{{ item.key }}=.*$'
+        line: "{{ item.key }}={{ item.value['value'] }}"
+        state: present
+      with_dict: "{{ inventory }}"
+      when: item.value.disabled is defined and not item.value.disabled
+
+    - name: Remove disabled settings in the awx inventory file from upstream
+      lineinfile:
+        destfile: "{{ awx_repo_dir }}/installer/inventory"
+        regexp: '^\s*{{ item.key }}=.*$'
+        state: absent
+        backup: true 
+      with_dict: "{{ inventory }}"
+      when: item.value.disabled is defined and item.value.disabled
+
+    - name: Run the AWX installation playbook without command line args.
+      command: "ansible-playbook -i inventory install.yml"
+      args:
+        chdir: "{{ awx_repo_dir }}/installer"
+        creates: /etc/awx_playbook_complete
+  when: modify_awx_inventory
+  
 - name: Create a file to mark whether this playbook has completed.
   file:
     path: /etc/awx_playbook_complete

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ awx_package_dependencies }}"
+  when: inventory.dockerhub_base.disabled and inventory.dockerhub_version.disabled
 
 - name: Clone AWX into configured directory.
   git:


### PR DESCRIPTION
Changes allow to use either command line options with the awx installer
or change the settings within the inventory file. The later seems to be
the better option, as one could remove lines like `dockerhub_base` and
`dockerhub_latest` to build your own images. Build requirements are only
installed if those to options are disabled.

The changes involve a more sophisticated datastructure in the
defaults file.

This is a proof of concept and should be discussed in detail.