### PR TITLE
Add support for proxy & project dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,6 @@ awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
 postgres_data_dir: /var/lib/pgdocker
+project_data_dir: /var/lib/awx/projects
+http_proxy: ""
+https_proxy: ""

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,6 +1,11 @@
 ---
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }}"
+  command: >
+    ansible-playbook -i inventory install.yml
+    -e postgres_data_dir={{ postgres_data_dir }}
+    -e project_data_dir={{ project_data_dir }}
+    -e http_proxy={{ http_proxy }}
+    -e https_proxy={{ https_proxy }}
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete


### PR DESCRIPTION
## Issues ?

- `Failed connect to github.com:443` when adding project using git, and host behind proxy.
- User can't specify project base path.

## What does this do ?

- Add `http_proxy` and `https_proxy` var to support docker behind proxy.
- Add `project_data_dir` var to support changing project base dir
- Add `http_proxy`, `https_proxy` and `project_data_dir` extra vars when executing install.yml