### PR TITLE
Added support for custom AWX install inventory.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
 postgres_data_dir: /var/lib/pgdocker
+awx_inventory: inventory

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }}"
+  command: "ansible-playbook -i {{ awx_inventory }} install.yml -e postgres_data_dir={{ postgres_data_dir }}"
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete


### PR DESCRIPTION
For production use of Ansible AWX, it's helpful to specify a custom docker hub version for the awx_web and awx_task containers. By specifying a custom inventory file, this inventory can be  configured as a template in pre_tasks and Ansible AWX can use it as a base for the installer. Also helpful to set custom DB details.