### PR TITLE
Adjust AWX Install Playbook Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,24 @@ Available variables are listed below, along with default values (see `defaults/m
     awx_repo_dir: "~/awx"
     awx_version: devel
     awx_keep_updated: true
+    awx_modify_inventory: true
+    awx_inventory:
+        dockerhub_base:
+            value: ansible
+            disabled: false
+        dockerhub_version:
+            value: latest
+            disabled: false
+        postgres_data_dir:
+            value: /var/lib/pgdocker
 
 Variables to control what version of AWX is checked out and installed.
 
     awx_run_install_playbook: true
 
 By default, this role will run the installation playbook included with AWX (which builds a set of containers and runs them). You can disable the playbook run by setting this variable to `no`.
+
+Additionally, this role also lets you modify the installation variables included with AWX, which are adjusted in the AWX [inventory file](https://github.com/ansible/awx/blob/devel/installer/inventory). By modifying the `awx_inventory` variable, new values will be passed into the installer playbook provided by AWX.
 
 ## Dependencies
 
@@ -42,12 +54,12 @@ None.
 
     - hosts: awx-centos
       become: true
-    
+
       vars:
         nodejs_version: "6.x"
         pip_install_packages:
           - name: docker-py
-    
+
       roles:
         - geerlingguy.repo-epel
         - geerlingguy.git

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@
 awx_repo: https://github.com/ansible/awx.git
 awx_repo_dir: "~/awx"
 awx_version: devel
-awx_keep_updated: yes
-awx_run_install_playbook: yes
+awx_keep_updated: true
+awx_run_install_playbook: true
 awx_modify_inventory: true
 awx_inventory:
     dockerhub_base:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
 awx_modify_inventory: true
-inventory:
+awx_inventory:
     dockerhub_base:
         value: ansible
         disabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,15 @@
 awx_repo: https://github.com/ansible/awx.git
 awx_repo_dir: "~/awx"
 awx_version: devel
-awx_keep_updated: true
-awx_run_install_playbook: true
-postgres_data_dir: /var/lib/pgdocker
+awx_keep_updated: yes
+awx_run_install_playbook: yes
+modify_awx_inventory: true
+inventory:
+    dockerhub_base:
+        value: ansible
+        disabled: false
+    dockerhub_version:
+        value: latest
+        disabled: false
+    postgres_data_dir:
+        value: /var/lib/pgdocker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ awx_repo_dir: "~/awx"
 awx_version: devel
 awx_keep_updated: yes
 awx_run_install_playbook: yes
-modify_awx_inventory: true
+awx_modify_inventory: true
 inventory:
     dockerhub_base:
         value: ansible

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -4,7 +4,7 @@
     - name: create command line options when not using the inventory.
       set_fact:
         installer_args: |
-            {% for k,v in inventory.iteritems() -%}
+            {% for k,v in awx_inventory.iteritems() -%}
             -e {{ k }}={{ v }}{{ '' if loop.last else ' ' }}
             {%- endfor -%}
 
@@ -23,7 +23,7 @@
         regexp: '^\s*{{ item.key }}=.*$'
         line: "{{ item.key }}={{ item.value['value'] }}"
         state: present
-      with_dict: "{{ inventory }}"
+      with_dict: "{{ awx_inventory }}"
       when: item.value.disabled is defined and not item.value.disabled
 
     - name: Remove disabled settings in the awx inventory file from upstream
@@ -32,7 +32,7 @@
         regexp: '^\s*{{ item.key }}=.*$'
         state: absent
         backup: true
-      with_dict: "{{ inventory }}"
+      with_dict: "{{ awx_inventory }}"
       when: item.value.disabled is defined and item.value.disabled
 
     - name: Run the AWX installation playbook without command line args.

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,10 +1,47 @@
 ---
-- name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }}"
-  args:
-    chdir: "{{ awx_repo_dir }}/installer"
-    creates: /etc/awx_playbook_complete
+- name: Run the installer with command line options
+  block:
+    - name: create command line options when not using the inventory.
+      set_fact: 
+        installer_args: |
+            {% for k,v in inventory.iteritems() -%}
+            -e {{ k }}={{ v }}{{ '' if loop.last else ' ' }}
+            {%- endfor -%}
 
+    - name: Run the AWX installation playbook with command line args.
+      command: "ansible-playbook -i inventory install.yml {{ installer_args }}"
+      args:
+        chdir: "{{ awx_repo_dir }}/installer"
+        creates: /etc/awx_playbook_complete
+  when: not modify_awx_inventory
+
+- name: Run the installer with the inventory file
+  block:
+    - name: Enable/Change settings in the awx inventory file from upstream
+      lineinfile:
+        destfile: "{{ awx_repo_dir }}/installer/inventory"
+        regexp: '^\s*{{ item.key }}=.*$'
+        line: "{{ item.key }}={{ item.value['value'] }}"
+        state: present
+      with_dict: "{{ inventory }}"
+      when: item.value.disabled is defined and not item.value.disabled
+
+    - name: Remove disabled settings in the awx inventory file from upstream
+      lineinfile:
+        destfile: "{{ awx_repo_dir }}/installer/inventory"
+        regexp: '^\s*{{ item.key }}=.*$'
+        state: absent
+        backup: true 
+      with_dict: "{{ inventory }}"
+      when: item.value.disabled is defined and item.value.disabled
+
+    - name: Run the AWX installation playbook without command line args.
+      command: "ansible-playbook -i inventory install.yml"
+      args:
+        chdir: "{{ awx_repo_dir }}/installer"
+        creates: /etc/awx_playbook_complete
+  when: modify_awx_inventory
+  
 - name: Create a file to mark whether this playbook has completed.
   file:
     path: /etc/awx_playbook_complete

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -2,7 +2,7 @@
 - name: Run the installer with command line options
   block:
     - name: create command line options when not using the inventory.
-      set_fact: 
+      set_fact:
         installer_args: |
             {% for k,v in inventory.iteritems() -%}
             -e {{ k }}={{ v }}{{ '' if loop.last else ' ' }}
@@ -13,7 +13,7 @@
       args:
         chdir: "{{ awx_repo_dir }}/installer"
         creates: /etc/awx_playbook_complete
-  when: not modify_awx_inventory
+  when: not awx_modify_inventory
 
 - name: Run the installer with the inventory file
   block:
@@ -31,7 +31,7 @@
         destfile: "{{ awx_repo_dir }}/installer/inventory"
         regexp: '^\s*{{ item.key }}=.*$'
         state: absent
-        backup: true 
+        backup: true
       with_dict: "{{ inventory }}"
       when: item.value.disabled is defined and item.value.disabled
 
@@ -40,8 +40,8 @@
       args:
         chdir: "{{ awx_repo_dir }}/installer"
         creates: /etc/awx_playbook_complete
-  when: modify_awx_inventory
-  
+  when: awx_modify_inventory
+
 - name: Create a file to mark whether this playbook has completed.
   file:
     path: /etc/awx_playbook_complete

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ awx_package_dependencies }}"
-  when: inventory.dockerhub_base.disabled and inventory.dockerhub_version.disabled
+  when: awx_inventory.dockerhub_base.disabled and awx_inventory.dockerhub_version.disabled
 
 - name: Clone AWX into configured directory.
   git:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ awx_package_dependencies }}"
+  when: inventory.dockerhub_base.disabled and inventory.dockerhub_version.disabled
 
 - name: Clone AWX into configured directory.
   git:


### PR DESCRIPTION
This is based off the work done by @hhenkel in #16; I've fixed the conflicts and adjusted his original variable names used.

As stated in #16, using this role as-is doesn't allow us to adjust configuration options in the AWX installer playbook. MR #5 makes a step in the right direction, however that is only a one-off for one specific configuration variable.  With this change, we can arbitrarily pass variables to the AWX installation playbook.

**IMPORTANT NOTES ABOUT THIS MR:** With this implementation, we no longer use the `postgres_data_dir` variable, so releasing a new version of this role should probably be a major release.