### PR TITLE
create docker_compose variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ awx_version: devel
 awx_keep_updated: true
 awx_run_install_playbook: true
 postgres_data_dir: /var/lib/pgdocker
+docker_compose_dir: /var/awx/awxcompose

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }}, docker_compose_dir={{ docker_compose_dir }}"
+  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }},docker_compose_dir={{ docker_compose_dir }}"
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }}"
+  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }} docker_compose_dir={{ docker_compose_dir }}"
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }} docker_compose_dir={{ docker_compose_dir }}"
+  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }}, docker_compose_dir={{ docker_compose_dir }}"
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete


### PR DESCRIPTION
At present setting the docker_compose directory is hard coded to `docker_compose_dir=/tmp/awxcompose`.  This adds a variable for the directory location and to the AWX installation playbook so it's not always maintained within the /tmp directory.  