### PR TITLE
Updating to include python3 requirements for awx install.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,11 @@
     force: true
     accept_hostkey: true
 
+- name: Install Docker SDK & docker-compose
+  pip:
+    name: ['docker', 'docker-compose']
+    executable: pip3.6
+    state: present
+
 - include: awx-install-playbook.yml
   when: awx_run_install_playbook

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,3 +4,6 @@ awx_package_dependencies:
   - gettext
   - gcc-c++
   - bzip2
+  - python3
+  - python3-pip
+  - libselinux-python3


### PR DESCRIPTION
I found that AWX is now forcing the python3 interpreter to be used when running their install.yml via the included inventory file. This required that I install python3 and a number of dependencies to get it up and running on CentOS 7.8.2003. It is possible that some of this should be accomplished via your docker role instead.