### PR TITLE
Add required docker restart and permissions for docker

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,18 @@
 
 - include: awx-install-playbook.yml
   when: awx_run_install_playbook
+
+- name: Add vagrant user to docker group
+  user:
+    name: vagrant
+    groups: docker
+    append: yes
+
+- name: Pause for 30 seconds to permit awx_task to start
+  pause:
+    seconds: 30
+
+- name: Restart container service
+  service:
+    name: docker
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,12 +20,6 @@
 - include: awx-install-playbook.yml
   when: awx_run_install_playbook
 
-- name: Add vagrant user to docker group
-  user:
-    name: vagrant
-    groups: docker
-    append: yes
-
 - name: Pause for 30 seconds to permit awx_task to start
   pause:
     seconds: 30

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,3 +4,5 @@ awx_package_dependencies:
   - gettext
   - gcc-c++
   - bzip2
+  - python36-docker
+  - libselinux-python3


### PR DESCRIPTION
1. Adding ease of use change putting vagrant user in docker group so users can run docker commands to trail logs or view containers and state
2. Adding pause and docker service restart to get around reliable bug in AWX

With these changes Cent7 AWX deploys every time with no further actions. 

Code isn't as clean as yours (yet!) - I'm new to Ansible. Please clean up and modify whatever needed. 

Related to PR: https://github.com/geerlingguy/ansible-vagrant-examples/pull/84