### PR TITLE
Add the ability to set key AWX secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-v2.1.0 (unreleased)
+v2.1.0 - Tagged by Zorlin
 * Add a conditional for whether to use the AWX race condition workaround
 * Allow users to specify the credentials and encryption keys to use
 
-v2.0.0 - Tagged by @geerlingguy
+v2.0.0 - Tagged by geerlingguy
 * Latest release on GitHub before fork

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v2.1.0 (unreleased)
 * Add a conditional for whether to use the AWX race condition workaround
+* Allow users to specify the credentials and encryption keys to use
 
 v2.0.0 - Tagged by @geerlingguy
 * Latest release on GitHub before fork

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v2.1.2 - Tagged by Zorlin
+* Change the way the "default secrets" warnings work
+* Default to using the race condition workaround
+
 v2.1.1 - Tagged by Zorlin
 * Fix some minor issues brought up by the linters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v2.1.1 - Tagged by Zorlin
+* Fix some minor issues brought up by the linters
+
 v2.1.0 - Tagged by Zorlin
 * Add a conditional for whether to use the AWX race condition workaround
 * Allow users to specify the credentials and encryption keys to use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+v2.1.0 (unreleased)
+* Add a conditional for whether to use the AWX race condition workaround
+
+v2.0.0 - Tagged by @geerlingguy
+* Latest release on GitHub before fork

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ By default, this role will run the installation playbook included with AWX (whic
 
 Variables to control AWX workarounds:
 
-    awx_workaround: false
+    awx_workaround: true
 
-By default, this role will no longer use a workaround that was previously necessary when running AWX for the first time after installation. You can re-enable the workaround by setting this variable to `true`.
+By default, this role will use a workaround that is sometimes necessary when running AWX for the first time after installation. You can disnable the workaround by setting this variable to `false`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Available variables are listed below, along with default values (see `defaults/m
     awx_version: devel
     awx_keep_updated: true
 
+Key and password variables:
+
+    awx_admin_password: password
+    awx_pg_password: awxpass
+    awx_secret_key: awxsecret
+
+These are the default passwords and keys used when deploying AWX. For a production setup, it's **highly recommended** that you change all of them, especially the secret key. The playbook will warn you if you are using the default admin password or secret key.
+
 Variables to control what version of AWX is checked out and installed.
 
     awx_run_install_playbook: true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Variables to control what version of AWX is checked out and installed.
 
 By default, this role will run the installation playbook included with AWX (which builds a set of containers and runs them). You can disable the playbook run by setting this variable to `false`.
 
+Variables to control AWX workarounds:
+
+    awx_workaround: false
+
+By default, this role will no longer use a workaround that was previously necessary when running AWX for the first time after installation. You can re-enable the workaround by setting this variable to `true`.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,5 @@ awx_repo_dir: "~/awx"
 awx_version: devel
 awx_keep_updated: true
 awx_run_install_playbook: true
+awx_workaround: false
 postgres_data_dir: /var/lib/pgdocker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,4 +5,8 @@ awx_version: devel
 awx_keep_updated: true
 awx_run_install_playbook: true
 awx_workaround: false
+awx_secrets_path: "~/.awx_secrets.yml"
+awx_admin_password: password
+awx_pg_password: awxpass
+awx_secret_key: awxsecret
 postgres_data_dir: /var/lib/pgdocker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ awx_repo_dir: "~/awx"
 awx_version: devel
 awx_keep_updated: true
 awx_run_install_playbook: true
-awx_workaround: false
+awx_workaround: true
 awx_secrets_path: "~/.awx_secrets.yml"
 awx_admin_password: password
 awx_pg_password: awxpass

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -5,7 +5,7 @@
   register: awx_playbook_already_run
 
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }}"
+  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }} @$HOME/.awx_secrets.yml"
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -34,10 +34,8 @@
   debug:
     msg: "WARNING: You are using the default awx_secret_key. This is insecure, but fine for testing."
   when: awx_secret_key == 'awxsecret'
-  changed_when: true
 
 - name: Check if we are using the default AWX admin password
   debug:
     msg: "WARNING: You are using the default AWX admin password. Make sure to change it after installation!"
   when: awx_admin_password == 'password'
-  changed_when: true

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -21,18 +21,18 @@
 - name: Pause for 30 seconds to permit awx_task to start
   pause:
     seconds: 30
-  when: not awx_playbook_already_run.stat.exists and awx_workaround == true
+  when: not awx_playbook_already_run.stat.exists and awx_workaround
 
 - name: Restart container service
   service:
     name: docker
     state: restarted
-  when: not awx_playbook_already_run.stat.exists and awx_workaround == true
+  when: not awx_playbook_already_run.stat.exists and awx_workaround
 
 # Emit warnings if needed
 - name: Check if we are using the default secret key
   debug:
-    msg: "WARNING: You are using the default awx_secret_key. This is insecure, but fine for development and testing."
+    msg: "WARNING: You are using the default awx_secret_key. This is insecure, but fine for testing."
   when: awx_secret_key == 'awxsecret'
   changed_when: true
 

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -28,3 +28,16 @@
     name: docker
     state: restarted
   when: not awx_playbook_already_run.stat.exists and awx_workaround == true
+
+# Emit warnings if needed
+- name: Check if we are using the default secret key
+  debug:
+    msg: "WARNING: You are using the default awx_secret_key. This is insecure, but fine for development and testing."
+  when: awx_secret_key == 'awxsecret'
+  changed_when: true
+
+- name: Check if we are using the default AWX admin password
+  debug:
+    msg: "WARNING: You are using the default AWX admin password. Make sure to change it after installation!"
+  when: awx_admin_password == 'password'
+  changed_when: true

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -5,7 +5,7 @@
   register: awx_playbook_already_run
 
 - name: Run the AWX installation playbook.
-  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }} @$HOME/.awx_secrets.yml"
+  command: "ansible-playbook -i inventory install.yml -e postgres_data_dir={{ postgres_data_dir }} -e @$HOME/.awx_secrets.yml"
   args:
     chdir: "{{ awx_repo_dir }}/installer"
     creates: /etc/awx_playbook_complete

--- a/tasks/awx-install-playbook.yml
+++ b/tasks/awx-install-playbook.yml
@@ -21,10 +21,10 @@
 - name: Pause for 30 seconds to permit awx_task to start
   pause:
     seconds: 30
-  when: not awx_playbook_already_run.stat.exists
+  when: not awx_playbook_already_run.stat.exists and awx_workaround == true
 
 - name: Restart container service
   service:
     name: docker
     state: restarted
-  when: not awx_playbook_already_run.stat.exists
+  when: not awx_playbook_already_run.stat.exists and awx_workaround == true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,11 @@
     force: true
     accept_hostkey: true
 
+- name: Install a secrets file for AWX.
+  template:
+    src: ".awx_secrets.yml.j2"
+    dest: "{{ awx_secrets_path }}"
+    mode: "0400"
+
 - include: awx-install-playbook.yml
   when: awx_run_install_playbook

--- a/templates/.awx_secrets.yml.j2
+++ b/templates/.awx_secrets.yml.j2
@@ -1,0 +1,4 @@
+---
+admin_password: '{{ awx_admin_password }}'
+pg_password: '{{ awx_pg_password }}'
+secret_key: '{{ awx_secret_key }}'


### PR DESCRIPTION
Hi @geerlingguy,

I've made some improvements to the role, namely:

- Added the ability to set the AWX secret key, default admin password and the PostgreSQL password
- Added the ability to disable/enable the workaround for the race condition you described in the awx-install-playbook plays

Feedback appreciated :)

I'm using the modified role @ https://github.com/getglass/genesis-playbook if you want to see it "in action" - I know you've moved onto the docker-compose method but this is basically the same strategy as that now.